### PR TITLE
fix heading-depth option by coercing to int

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ const defaults = {
 const JSDOC = function (content, _options = {}, config) {
   const options = Object.assign({}, defaults, _options);
 
+  // this must be coerced to an int or jsdoc2md becomes confused
+  options['heading-depth'] = parseInt(options['heading-depth'], 10) || 2;
+
   const doc = jsdoc2md.renderSync(options);
   if (doc.length > 0) {
     return doc;


### PR DESCRIPTION
Hi,

Thanks for this module.  With markdown-magic, it seems all options (from the HTML comments) are treated as strings.  This means if an option is intended to be numeric, we can run into trouble.  I noticed this when using `heading-depth=3`; the resulting markdown had some stuff that was seven (7) levels deep, when it should have only been four (4).

This PR ensures `heading-depth` is an integer, and fixes my problem.

Before:

![image](https://user-images.githubusercontent.com/924465/49781198-a793b700-fcc6-11e8-948f-4d6425c2b442.png)

After fix:

![image](https://user-images.githubusercontent.com/924465/49781211-b5e1d300-fcc6-11e8-9d0b-f6cf828fa386.png)
